### PR TITLE
Fix exception when re-opening About dialog after closing it

### DIFF
--- a/src/HolzShots.Windows/Forms/AboutForm.Designer.cs
+++ b/src/HolzShots.Windows/Forms/AboutForm.Designer.cs
@@ -146,6 +146,7 @@ namespace HolzShots.Windows.Forms
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "About";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.AboutForm_FormClosed);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/src/HolzShots.Windows/Forms/AboutForm.cs
+++ b/src/HolzShots.Windows/Forms/AboutForm.cs
@@ -25,6 +25,11 @@ namespace HolzShots.Windows.Forms
             const string title = "About Graphics";
             MessageBox.Show(this, AboutDialog.GetGraphicsText(), title);
         }
+
+        private void AboutForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            _instance = new Lazy<AboutForm>(() => new AboutForm());
+        }
     }
 
     public static class AboutDialog


### PR DESCRIPTION
Hi there, very cool project! 😄

Feel free to close this if you're not taking PRs, but I noticed something when testing HolzShots and thought I could contribute a small fix.

**The issue:** if you open the "About" dialog, close it, and the open it again, an Exception is thrown because the Value of the Lazy has been disposed already.

![image](https://user-images.githubusercontent.com/5004786/137601723-648a220f-bced-44bd-b378-da29655e7ce7.png)

The easiest way I could think of to fix this was to ensure that the `Lazy<AboutForm>` was reset whenever the `Instance` was closed, and it seems to work well.